### PR TITLE
dump_only unknown fields break singularity

### DIFF
--- a/backend/Hinkskalle/models/Collection.py
+++ b/backend/Hinkskalle/models/Collection.py
@@ -1,19 +1,20 @@
 from Hinkskalle import db
 from marshmallow import Schema, fields, validates_schema, ValidationError
+from ..util.schema import BaseSchema, LocalDateTime
 from datetime import datetime
 from sqlalchemy.orm import validates
 from Hinkskalle.util.name_check import validate_name
 
 from Hinkskalle.models.User import User
 
-class CollectionSchema(Schema):
+class CollectionSchema(BaseSchema):
   id = fields.String(required=True, dump_only=True)
   name = fields.String(required=True)
   description = fields.String(allow_none=True)
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(allow_none=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
   size = fields.Integer(dump_only=True)
   private = fields.Boolean()

--- a/backend/Hinkskalle/models/Container.py
+++ b/backend/Hinkskalle/models/Container.py
@@ -12,7 +12,8 @@ from Hinkskalle.models.Tag import Tag
 from Hinkskalle.models.User import User
 
 from marshmallow import fields, Schema, validates_schema, ValidationError
-from Hinkskalle.util.name_check import validate_name
+from ..util.name_check import validate_name
+from ..util.schema import BaseSchema, LocalDateTime
 
 class ContainerTypes(enum.Enum):
   singularity = 'singularity'
@@ -21,7 +22,7 @@ class ContainerTypes(enum.Enum):
   mixed = 'mixed'
 
 
-class ContainerSchema(Schema):
+class ContainerSchema(BaseSchema):
   id = fields.String(dump_only=True, required=True)
   name = fields.String(required=True)
   description = fields.String(allow_none=True)
@@ -35,10 +36,10 @@ class ContainerSchema(Schema):
   customData = fields.String(allow_none=True)
   vcsUrl = fields.String(allow_none=True)
   usedQuota = fields.Integer(dump_only=True, attribute='used_quota')
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(allow_none=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
 
   # image ids, not used? keep to validate schema

--- a/backend/Hinkskalle/models/Entity.py
+++ b/backend/Hinkskalle/models/Entity.py
@@ -1,21 +1,22 @@
 from asyncio.proactor_events import _ProactorBaseWritePipeTransport
 from Hinkskalle import db
-from marshmallow import fields, Schema, validates_schema, ValidationError
+from marshmallow import fields, validates_schema, ValidationError
 from datetime import datetime
 from sqlalchemy.orm import validates
 from flask import current_app
 from Hinkskalle.models.Image import UploadStates
 from Hinkskalle.util.name_check import validate_name
 from Hinkskalle.models.User import User
+from ..util.schema import LocalDateTime, BaseSchema
 
-class EntitySchema(Schema):
+class EntitySchema(BaseSchema):
   id = fields.String(required=True, dump_only=True)
   name = fields.String(required=True)
   description = fields.String(allow_none=True)
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(allow_none=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
   size = fields.Integer(dump_only=True)
   quota = fields.Integer()
@@ -30,6 +31,7 @@ class EntitySchema(Schema):
     errors = validate_name(data)
     if errors:
       raise ValidationError(errors)
+    
 
 class Entity(db.Model):
   id = db.Column(db.Integer, primary_key=True)

--- a/backend/Hinkskalle/models/Image.py
+++ b/backend/Hinkskalle/models/Image.py
@@ -15,8 +15,10 @@ import enum
 import os.path
 import subprocess
 
+from ..util.schema import BaseSchema, LocalDateTime
 
-class ImageSchema(Schema):
+
+class ImageSchema(BaseSchema):
   id = fields.String(required=True, dump_only=True)
   description = fields.String(allow_none=True)
   hash = fields.String(allow_none=True)
@@ -34,12 +36,12 @@ class ImageSchema(Schema):
   containerDownloads = fields.Integer(dump_only=True)
   downloadCount = fields.Integer(dump_only=True)
 
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(dump_only=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  expiresAt = fields.DateTime(allow_none=True)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  expiresAt = LocalDateTime(allow_none=True)
 
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
 
   container = fields.String(required=True)

--- a/backend/Hinkskalle/models/Manifest.py
+++ b/backend/Hinkskalle/models/Manifest.py
@@ -10,6 +10,7 @@ import json
 import hashlib
 from sqlalchemy.ext.hybrid import hybrid_property
 from marshmallow import Schema, fields
+from ..util.schema import BaseSchema, LocalDateTime
 
 class ManifestTypes(enum.Enum):
   docker = 'docker'
@@ -45,12 +46,12 @@ class ManifestContentSchema(Schema):
   layers = fields.Nested(ManifestLayerSchema, many=True)
   annotations = fields.Dict()
 
-class ManifestSchema(Schema):
+class ManifestSchema(BaseSchema):
   id = fields.String(dump_only=True)
   hash = fields.String()
   content = fields.Dict(attribute='content_json')
-  createdAt = fields.DateTime(dump_only=True)
-  updatedAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
+  updatedAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(dump_only=True)
 
   type = fields.String(dump_only=True)

--- a/backend/Hinkskalle/models/User.py
+++ b/backend/Hinkskalle/models/User.py
@@ -19,7 +19,7 @@ user_groups_table = db.Table('users_groups', db.metadata,
   db.Column('group_id', db.Integer, db.ForeignKey('group.id'), nullable=False),
 )
 
-class UserSchema(LocalSchema):
+class UserSchema(BaseSchema):
   id = fields.String(required=True, dump_only=True)
   username = fields.String(required=True)
   email = fields.String(required=True)

--- a/backend/Hinkskalle/models/User.py
+++ b/backend/Hinkskalle/models/User.py
@@ -7,6 +7,8 @@ from sqlalchemy.orm import validates
 from passlib.hash import sha512_crypt
 import secrets
 
+from ..util.schema import BaseSchema, LocalDateTime
+
 user_stars = db.Table('user_stars', db.metadata,
   db.Column('user_id', db.Integer, db.ForeignKey('user.id'), nullable=False),
   db.Column('container_id', db.Integer, db.ForeignKey('container.id'), nullable=False),
@@ -17,7 +19,7 @@ user_groups_table = db.Table('users_groups', db.metadata,
   db.Column('group_id', db.Integer, db.ForeignKey('group.id'), nullable=False),
 )
 
-class UserSchema(Schema):
+class UserSchema(LocalSchema):
   id = fields.String(required=True, dump_only=True)
   username = fields.String(required=True)
   email = fields.String(required=True)
@@ -29,10 +31,10 @@ class UserSchema(Schema):
 
   groups = fields.List(fields.Nested('GroupSchema', allow_none=True, exclude=('users', )))
 
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(dump_only=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
 
 
@@ -116,17 +118,17 @@ class User(db.Model):
       return False
 
 
-class GroupSchema(Schema):
+class GroupSchema(BaseSchema):
   id = fields.String(required=True, dump_only=True)
   name = fields.String(required=True)
   email = fields.String(required=True)
 
   users = fields.List(fields.Nested('UserSchema', allow_none=True, exclude=('groups', )))
 
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(dump_only=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
   
 
@@ -141,20 +143,20 @@ class Group(db.Model):
   createdBy = db.Column(db.String())
   updatedAt = db.Column(db.DateTime)
 
-class TokenSchema(Schema):
+class TokenSchema(BaseSchema):
   id = fields.String(required=True, dump_only=True)
   token = fields.String(required=True, dump_only=True)
   comment = fields.String(allow_none=True)
 
   user = fields.Nested('UserSchema')
 
-  expiresAt = fields.DateTime(allow_none=True)
+  expiresAt = LocalDateTime(allow_none=True)
   source = fields.String(dump_only=True, allow_none=True)
 
-  createdAt = fields.DateTime(dump_only=True)
+  createdAt = LocalDateTime(dump_only=True)
   createdBy = fields.String(dump_only=True)
-  updatedAt = fields.DateTime(dump_only=True, allow_none=True)
-  deletedAt = fields.DateTime(dump_only=True, default=None)
+  updatedAt = LocalDateTime(dump_only=True, allow_none=True)
+  deletedAt = LocalDateTime(dump_only=True, default=None)
   deleted = fields.Boolean(dump_only=True, default=False)
 
 class Token(db.Model):

--- a/backend/Hinkskalle/routes/adm.py
+++ b/backend/Hinkskalle/routes/adm.py
@@ -9,6 +9,7 @@ from marshmallow import fields, Schema
 
 from Hinkskalle.models.Adm import AdmSchema, Adm, AdmKeys
 from flask_rq2.job import Job
+from ..util.schema import BaseSchema, LocalDateTime
 
 class AdmResponseSchema(ResponseSchema):
   data = fields.Nested(AdmSchema)
@@ -34,7 +35,7 @@ def _serialize_job(job: Job) -> dict:
     'funcName': job.func_name,
   }
 
-class JobSchema(Schema):
+class JobSchema(BaseSchema):
   id = fields.String()
   meta = fields.Dict()
   origin = fields.String()
@@ -46,9 +47,9 @@ class JobSchema(Schema):
   resultTTL = fields.Int()
   timeout = fields.String()
   result = fields.String(allow_none=True)
-  enqueuedAt = fields.DateTime()
-  startedAt = fields.DateTime(allow_none=True)
-  endedAt = fields.DateTime(allow_none=True)
+  enqueuedAt = LocalDateTime()
+  startedAt = LocalDateTime(allow_none=True)
+  endedAt = LocalDateTime(allow_none=True)
   excInfo = fields.String(allow_none=True)
   funcName = fields.String()
 

--- a/backend/Hinkskalle/routes/collections.py
+++ b/backend/Hinkskalle/routes/collections.py
@@ -32,7 +32,7 @@ class CollectionDeleteResponseSchema(ResponseSchema):
 @registry.handles(
   rule='/v1/collections',
   method='POST',
-  request_body_schema=CollectionCreateSchema(),
+  request_body_schema=CollectionCreateSchema(unknown='exclude'),
   response_body_schema=CollectionResponseSchema(),
   authenticators=authenticator.with_scope(Scopes.user), # type: ignore
   tags=['singularity'],

--- a/backend/Hinkskalle/routes/containers.py
+++ b/backend/Hinkskalle/routes/containers.py
@@ -85,7 +85,7 @@ def get_default_container(container_id):
 @registry.handles(
   rule='/v1/containers',
   method='POST',
-  request_body_schema=ContainerCreateSchema(),
+  request_body_schema=ContainerCreateSchema(unknown='exclude'),
   response_body_schema=ContainerResponseSchema(),
   authenticators=authenticator.with_scope(Scopes.user), # type: ignore
   tags=['hinkskalle-ext']

--- a/backend/Hinkskalle/routes/entities.py
+++ b/backend/Hinkskalle/routes/entities.py
@@ -67,14 +67,13 @@ def get_default_entity():
 @registry.handles(
   rule='/v1/entities',
   method='POST',
-  request_body_schema=EntityCreateSchema(),
+  request_body_schema=EntityCreateSchema(unknown='exclude'),
   response_body_schema=EntityResponseSchema(),
   authenticators=authenticator.with_scope(Scopes.user), # type: ignore
   tags=['singularity']
 )
 def create_entity():
   body = rebar.validated_body
-  current_app.logger.debug(body)
   body.pop('id', None)
   if body.get('name', '') == '':
     body['name']='default'

--- a/backend/Hinkskalle/routes/images.py
+++ b/backend/Hinkskalle/routes/images.py
@@ -181,7 +181,7 @@ def get_image_default_entity_default_collection_single(tagged_container_id):
 @registry.handles(
   rule='/v1/images',
   method='POST',
-  request_body_schema=ImageCreateSchema(),
+  request_body_schema=ImageCreateSchema(unknown='exclude'),
   response_body_schema=ImageResponseSchema(),
   authenticators=authenticator.with_scope(Scopes.user), # type: ignore
   tags=['hinkskalle-ext']

--- a/backend/Hinkskalle/routes/images.py
+++ b/backend/Hinkskalle/routes/images.py
@@ -275,8 +275,8 @@ def update_image(entity_id, collection_id, tagged_container_id):
     raise errors.Forbidden('access denied')
 
   if image.owner != g.authenticated_user:
-    if body.get('expiresAt') and body['expiresAt'] != image.expiresAt:
-      raise errors.Forbidden(f"Unable to change expiration date on admin generated image")
+    if body.get('expiresAt') and body['expiresAt'].replace(tzinfo=None) != image.expiresAt:
+      raise errors.Forbidden(f"Unable to change expiration date on admin generated image ({body.get('expiresAt')} <-> {image.expiresAt}")
   for key in body:
     setattr(image, key, body[key])
   image.updatedAt = datetime.datetime.now()

--- a/backend/Hinkskalle/routes/oras.py
+++ b/backend/Hinkskalle/routes/oras.py
@@ -33,6 +33,7 @@ from Hinkskalle.util.auth.exceptions import UserNotFound, UserDisabled, InvalidP
 from .util import _get_container as __get_container, _get_service_url
 from .imagefiles import _move_image, _receive_upload as __receive_upload, _rebuild_chunks
 from .images import _delete_image
+from ..util.schema import BaseSchema, LocalDateTime
 
 class OrasPushBlobQuerySchema(RequestSchema):
   digest = fields.String(required=True)
@@ -43,7 +44,7 @@ class OrasListTagQuerySchema(RequestSchema):
 
 class OrasBlobMountQuerySchema(RequestSchema):
   private = fields.Bool(required=False)
-  expiresAt = fields.DateTime(required=False, allow_none=True)
+  expiresAt = LocalDateTime(required=False, allow_none=True)
   staged = fields.Bool(required=False)
   digest = fields.String(required=False)
   mount = fields.String(required=False)

--- a/backend/Hinkskalle/tests/models/test_Adm.py
+++ b/backend/Hinkskalle/tests/models/test_Adm.py
@@ -12,7 +12,7 @@ class TestAdm(ModelBase):
 
     fromDb = Adm.query.get(AdmKeys.ldap_sync_results)
     self.assertDictEqual(fromDb.val, { 'knofel': 100 })
-    self.assertTrue(abs(fromDb.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(fromDb.createdAt - datetime.now()) < timedelta(seconds=2))
   
   def test_schema(self):
     schema = AdmSchema()

--- a/backend/Hinkskalle/tests/models/test_Collection.py
+++ b/backend/Hinkskalle/tests/models/test_Collection.py
@@ -13,7 +13,7 @@ class TestCollection(ModelBase):
 
     read_coll = Collection.query.filter_by(name='test-collection').one()
     self.assertEqual(read_coll.id, coll.id)
-    self.assertTrue(abs(read_coll.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(read_coll.createdAt - datetime.now()) < timedelta(seconds=2))
 
     self.assertEqual(read_coll.entity, entity.id)
     self.assertEqual(read_coll.entityName, entity.name)

--- a/backend/Hinkskalle/tests/models/test_Container.py
+++ b/backend/Hinkskalle/tests/models/test_Container.py
@@ -20,7 +20,7 @@ class TestContainer(ModelBase):
 
     read_container = Container.query.filter_by(name=container.name).one()
     self.assertEqual(read_container.id, container.id)
-    self.assertTrue(abs(read_container.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(read_container.createdAt - datetime.now()) < timedelta(seconds=2))
 
     self.assertEqual(read_container.collection, coll.id)
     self.assertEqual(read_container.collectionName, coll.name)
@@ -143,7 +143,7 @@ class TestContainer(ModelBase):
 
     new_tag = container.tag_image('v1', image1.id)
     self.assertEqual(new_tag.image_ref.id, image1.id)
-    self.assertTrue(abs(new_tag.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(new_tag.createdAt - datetime.now()) < timedelta(seconds=2))
     self.assertIsNone(new_tag.updatedAt)
     tags = Tag.query.filter(Tag.image_id.in_([ c.id for c in container.images_ref ])).all()
     self.assertListEqual(
@@ -153,7 +153,7 @@ class TestContainer(ModelBase):
 
     new_tag = container.tag_image('v1', image1.id)
     self.assertEqual(new_tag.image_ref.id, image1.id)
-    self.assertTrue(abs(new_tag.updatedAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(new_tag.updatedAt - datetime.now()) < timedelta(seconds=2))
     tags = Tag.query.filter(Tag.image_id.in_([ c.id for c in container.images_ref ])).all()
     self.assertListEqual(
       [f"{tag.name}:{tag.image_ref.id}" for tag in tags ],
@@ -162,7 +162,7 @@ class TestContainer(ModelBase):
 
     new_tag = container.tag_image('v1.1', image1.id)
     self.assertEqual(new_tag.image_ref.id, image1.id)
-    self.assertTrue(abs(new_tag.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(new_tag.createdAt - datetime.now()) < timedelta(seconds=2))
     self.assertIsNone(new_tag.updatedAt)
     tags = Tag.query.filter(Tag.image_id.in_([ c.id for c in container.images_ref ])).all()
     self.assertListEqual(
@@ -176,7 +176,7 @@ class TestContainer(ModelBase):
 
     new_tag = container.tag_image('v2', image2.id)
     self.assertEqual(new_tag.image_ref.id, image2.id)
-    self.assertTrue(abs(new_tag.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(new_tag.createdAt - datetime.now()) < timedelta(seconds=2))
     self.assertIsNone(new_tag.updatedAt)
     tags = Tag.query.filter(Tag.image_id.in_([ c.id for c in container.images_ref ])).all()
     self.assertListEqual(
@@ -186,7 +186,7 @@ class TestContainer(ModelBase):
 
     new_tag = container.tag_image('v1.1', image2.id)
     self.assertEqual(new_tag.image_ref.id, image2.id)
-    self.assertTrue(abs(new_tag.updatedAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(new_tag.updatedAt - datetime.now()) < timedelta(seconds=2))
     tags = Tag.query.filter(Tag.image_id.in_([ c.id for c in container.images_ref ])).all()
     self.assertListEqual(
       [f"{tag.name}:{tag.image_ref.id}" for tag in tags ],

--- a/backend/Hinkskalle/tests/models/test_Entity.py
+++ b/backend/Hinkskalle/tests/models/test_Entity.py
@@ -16,7 +16,7 @@ class TestEntity(ModelBase):
 
     read_entity = Entity.query.filter_by(name='test-hase').first()
     self.assertEqual(read_entity.id, entity.id)
-    self.assertTrue(abs(read_entity.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(read_entity.createdAt - datetime.now()) < timedelta(seconds=2))
   
   def test_entity_case(self):
     entity = Entity(name='TestHase')

--- a/backend/Hinkskalle/tests/models/test_Entity.py
+++ b/backend/Hinkskalle/tests/models/test_Entity.py
@@ -145,6 +145,8 @@ class TestEntity(ModelBase):
 
   def test_schema(self):
     entity = Entity(name='Test Hase')
+    db.session.add(entity)
+    db.session.commit()
     schema = EntitySchema()
     serialized = schema.dump(entity)
     self.assertEqual(serialized['id'], entity.id)
@@ -152,6 +154,8 @@ class TestEntity(ModelBase):
 
     self.assertIsNone(serialized['deletedAt'])
     self.assertFalse(serialized['deleted'])
+
+    self.assertRegex(serialized['createdAt'], r'[+-]?\d\d:\d\d$')
 
     entity.used_quota = 999
     serialized = schema.dump(entity)

--- a/backend/Hinkskalle/tests/models/test_Entity.py
+++ b/backend/Hinkskalle/tests/models/test_Entity.py
@@ -149,7 +149,7 @@ class TestEntity(ModelBase):
     db.session.commit()
     schema = EntitySchema()
     serialized = schema.dump(entity)
-    self.assertEqual(serialized['id'], entity.id)
+    self.assertEqual(serialized['id'], str(entity.id))
     self.assertEqual(serialized['name'], entity.name)
 
     self.assertIsNone(serialized['deletedAt'])

--- a/backend/Hinkskalle/tests/models/test_Group.py
+++ b/backend/Hinkskalle/tests/models/test_Group.py
@@ -15,7 +15,7 @@ class TestGroup(ModelBase):
 
     read_group = Group.query.filter_by(name='Testhasenstall').first()
     self.assertEqual(read_group.id, group.id)
-    self.assertTrue(abs(read_group.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(read_group.createdAt - datetime.now()) < timedelta(seconds=2))
   
   def test_schema(self):
     schema = GroupSchema()

--- a/backend/Hinkskalle/tests/models/test_Image.py
+++ b/backend/Hinkskalle/tests/models/test_Image.py
@@ -38,7 +38,7 @@ class TestImage(ModelBase):
     db.session.commit()
 
     read_image: Image = Image.query.get(image.id)
-    self.assertTrue(abs(read_image.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(read_image.createdAt - datetime.now()) < timedelta(seconds=2))
 
     self.assertEqual(read_image.container, container.id)
     self.assertEqual(read_image.containerName, container.name)

--- a/backend/Hinkskalle/tests/models/test_User.py
+++ b/backend/Hinkskalle/tests/models/test_User.py
@@ -15,7 +15,7 @@ class TestUser(ModelBase):
 
     read_user = User.query.filter_by(username='test.hase').first()
     self.assertEqual(read_user.id, user.id)
-    self.assertTrue(abs(read_user.createdAt - datetime.now()) < timedelta(seconds=1))
+    self.assertTrue(abs(read_user.createdAt - datetime.now()) < timedelta(seconds=2))
     self.assertFalse(read_user.is_admin)
   
   def test_user_case(self):

--- a/backend/Hinkskalle/tests/routes/test_collections.py
+++ b/backend/Hinkskalle/tests/routes/test_collections.py
@@ -214,7 +214,7 @@ class TestCollections(RouteBase):
     self.assertEqual(data['createdBy'], self.admin_username)
 
     db_collection = Collection.query.get(data['id'])
-    self.assertTrue(abs(db_collection.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(db_collection.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
   
   def test_create_singularity(self):
     entity = Entity(name='test-hase', owner=self.user)
@@ -436,7 +436,7 @@ class TestCollections(RouteBase):
     self.assertTrue(dbColl.private)
     self.assertEqual(dbColl.customData, 'hot drei Eckn')
 
-    self.assertTrue(abs(dbColl.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(dbColl.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
   
   def test_update_dumponly(self):
     coll, entity = _create_collection('grunz')

--- a/backend/Hinkskalle/tests/routes/test_collections.py
+++ b/backend/Hinkskalle/tests/routes/test_collections.py
@@ -215,6 +215,28 @@ class TestCollections(RouteBase):
 
     db_collection = Collection.query.get(data['id'])
     self.assertTrue(abs(db_collection.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+  
+  def test_create_singularity(self):
+    entity = Entity(name='test-hase', owner=self.user)
+    db.session.add(entity)
+    db.session.commit()
+    with self.fake_admin_auth():
+      ret = self.client.post('/v1/collections', json={
+        'deleted': False, 
+        'createdBy': '', 
+        'createdAt': '0001-01-01T00:00:00Z', 
+        'updatedAt': '0001-01-01T00:00:00Z', 
+        'deletedAt': '0001-01-01T00:00:00Z', 
+        'id': '', 
+        'name': 'os', 
+        'description': 'No description', 
+        'entity': str(entity.id), 
+        'containers': None, 
+        'size': 0, 
+        'private': False, 
+        'customData': ''
+    })
+    self.assertEqual(ret.status_code, 200)
 
   def test_create_behalf(self):
     entity = Entity(name='test-hase', owner=self.user)

--- a/backend/Hinkskalle/tests/routes/test_containers.py
+++ b/backend/Hinkskalle/tests/routes/test_containers.py
@@ -370,7 +370,7 @@ class TestContainers(RouteBase):
     self.assertTrue(dbContainer.readOnly)
     self.assertEqual(dbContainer.vcsUrl, 'http://da.ham')
 
-    self.assertTrue(abs(dbContainer.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(dbContainer.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
   
   def test_update_dumponly(self):
     container, coll, entity = _create_container('grunz')

--- a/backend/Hinkskalle/tests/routes/test_containers.py
+++ b/backend/Hinkskalle/tests/routes/test_containers.py
@@ -214,6 +214,32 @@ class TestContainers(RouteBase):
     self.assertEqual(data['collection'], str(coll.id))
     self.assertEqual(data['createdBy'], self.admin_username)
   
+  def test_create_singularity(self):
+    coll, _ = _create_collection()
+    with self.fake_admin_auth():
+      ret = self.client.post('/v1/containers', json={
+        'deleted': False, 
+        'createdBy': '', 
+        'createdAt': '0001-01-01T00:00:00Z', 
+        'updatedAt': '0001-01-01T00:00:00Z', 
+        'deletedAt': '0001-01-01T00:00:00Z', 
+        'id': '', 
+        'name': 'alpine', 
+        'description': 'No description', 
+        'fullDescription': '', 
+        'collection': str(coll.id), 
+        'images': None, 
+        'imageTags': None, 
+        'archTags': None, 
+        'size': 0, 
+        'downloadCount': 0, 
+        'stars': 0, 
+        'private': False, 
+        'readOnly': False, 
+        'customData': ''
+    })
+    self.assertEqual(ret.status_code, 200)
+  
   def test_create_sticky(self):
     coll, entity = _create_collection()
     entity.owner = self.user

--- a/backend/Hinkskalle/tests/routes/test_entities.py
+++ b/backend/Hinkskalle/tests/routes/test_entities.py
@@ -146,7 +146,7 @@ class TestEntities(RouteBase):
     self.assertEqual(data['createdBy'], self.admin_username)
 
     db_entity = Entity.query.get(data['id'])
-    self.assertTrue(abs(db_entity.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(db_entity.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
   
   def test_create_singularity(self):
     with self.fake_admin_auth():
@@ -264,7 +264,7 @@ class TestEntities(RouteBase):
     dbEntity = Entity.query.filter(Entity.name=='grunz').one()
     self.assertEqual(dbEntity.description, 'Oink oink')
     self.assertTrue(dbEntity.defaultPrivate)
-    self.assertTrue(abs(dbEntity.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(dbEntity.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
     
     with self.fake_admin_auth():
       ret = self.client.put('/v1/entities/grunz', json={

--- a/backend/Hinkskalle/tests/routes/test_entities.py
+++ b/backend/Hinkskalle/tests/routes/test_entities.py
@@ -148,6 +148,25 @@ class TestEntities(RouteBase):
     db_entity = Entity.query.get(data['id'])
     self.assertTrue(abs(db_entity.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
   
+  def test_create_singularity(self):
+    with self.fake_admin_auth():
+      ret = self.client.post('/v1/entities', json={
+        'deleted': False, 
+        'createdBy': '', 
+        'createdAt': '0001-01-01T00:00:00Z', 
+        'updatedAt': '0001-01-01T00:00:00Z', 
+        'deletedAt': '0001-01-01T00:00:00Z', 
+        'id': '', 
+        'name': 'barba.rix', 
+        'description': 'No description', 
+        'collections': None, 
+        'size': 0, 
+        'quota': 0, 
+        'defaultPrivate': False, 
+        'customData': ''
+    })
+    self.assertEqual(ret.status_code, 200)
+  
   def test_create_check_name(self):
     for fail in ['Babsi Streusand', '-oink', '_oink', '.oink', 'Babsi&Streusand', 'oink-', 'oink.', 'oink_']:
       with self.fake_admin_auth():

--- a/backend/Hinkskalle/tests/routes/test_images.py
+++ b/backend/Hinkskalle/tests/routes/test_images.py
@@ -589,7 +589,7 @@ class TestImages(RouteBase):
     self.assertEqual(dbImage.description, 'Mei Huat')
     self.assertEqual(dbImage.customData, 'hot drei Eckn')
 
-    self.assertTrue(abs(dbImage.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(dbImage.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
   
   def test_update_dumponly(self):
     image = _create_image()[0]

--- a/backend/Hinkskalle/tests/routes/test_images.py
+++ b/backend/Hinkskalle/tests/routes/test_images.py
@@ -328,6 +328,28 @@ class TestImages(RouteBase):
     self.assertEqual(data['hash'], 'sha256.oink')
     self.assertEqual(data['container'], str(container.id))
     self.assertEqual(data['createdBy'], self.admin_username)
+  
+  def test_create_singularity(self):
+    container, _, _ = _create_container()
+    with self.fake_admin_auth():
+      ret = self.client.post('/v1/images', json={
+        'deleted': False, 
+        'createdBy': '', 
+        'createdAt': '0001-01-01T00:00:00Z', 
+        'updatedAt': '0001-01-01T00:00:00Z', 
+        'deletedAt': '0001-01-01T00:00:00Z', 
+        'id': '', 
+        'hash': 'sha256.c032321b292ab9ec25cdd4e4b57bba979629a24c35c97bb034898fc06472145d', 
+        'description': '', 
+        'container': str(container.id), 
+        'size': 0, 
+        'uploaded': False, 
+        'customData': '', 
+        'containerStars': 0, 
+        'containerDownloads': 0
+      })
+    self.assertEqual(ret.status_code, 200)
+
 
   def test_create_readonly(self):
     container, _, _ = _create_container()

--- a/backend/Hinkskalle/tests/routes/test_users.py
+++ b/backend/Hinkskalle/tests/routes/test_users.py
@@ -273,7 +273,7 @@ class TestUsers(RouteBase):
     self.assertTrue(db_user.is_active)
     self.assertFalse(db_user.is_admin)
     self.assertIsNone(db_user.createdBy)
-    self.assertTrue(abs(db_user.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(db_user.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
 
     db_entity = Entity.query.filter(Entity.name==user_data['username']).first()
     self.assertIsNotNone(db_entity)
@@ -303,7 +303,7 @@ class TestUsers(RouteBase):
       self.assertEqual(getattr(db_user, uf), user_data[f])
     self.assertTrue(db_user.check_password(user_data['password']))
     self.assertEqual(db_user.createdBy, self.admin_username)
-    self.assertTrue(abs(db_user.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(db_user.createdAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
   
   def test_create_entity(self):
     user_data = {
@@ -393,7 +393,7 @@ class TestUsers(RouteBase):
     for f in ['email', 'firstname', 'lastname', 'source', 'isAdmin', 'isActive']:
       uf = 'is_active' if f == 'isActive' else 'is_admin' if f == 'isAdmin' else f
       self.assertEqual(getattr(db_user, uf), update_data[f])
-    self.assertTrue(abs(db_user.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=1))
+    self.assertTrue(abs(db_user.updatedAt - datetime.datetime.now()) < datetime.timedelta(seconds=2))
 
   def test_update_password(self):
     user_data = {

--- a/backend/Hinkskalle/util/schema.py
+++ b/backend/Hinkskalle/util/schema.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from marshmallow import Schema, fields
+from marshmallow.utils import is_aware
+from dateutil.tz import tzlocal
+import datetime as dt
+
+class BaseSchema(Schema):
+  class Meta:
+    datetimeformat = 'iso'
+
+class LocalDateTime(fields.AwareDateTime):
+    def __init__(
+        self,
+        format: str | None = None,
+        *,
+        default_timezone: dt.tzinfo | None = tzlocal(),
+        **kwargs,
+    ):
+        super().__init__(format=format, **kwargs)
+        self.default_timezone = default_timezone
+
+    def _serialize(self, value, attr, obj, **kwargs):
+      if value is not None and not is_aware(value):
+        lvalue = value.replace(tzinfo=self.default_timezone)
+      else:
+        lvalue = value
+      return super()._serialize(lvalue, attr, obj, **kwargs)


### PR DESCRIPTION
singularity sends dump_only fields, marshmallow does not recognize them any more after update. need unknown ignore, also add tests

flask rebar/marshmallow also no longer convert timezone naive datetimes to timezone; need to use a custom field