### PR TITLE
Make private: yes/no working

### DIFF
--- a/backend/Hinkskalle/models/Collection.py
+++ b/backend/Hinkskalle/models/Collection.py
@@ -76,6 +76,8 @@ class Collection(db.Model): # type: ignore
       return True
     elif self.owner == user:
       return True
+    elif self.private == False:
+      return True
     else:
       return self.entity_ref.check_access(user)
   

--- a/backend/Hinkskalle/models/Container.py
+++ b/backend/Hinkskalle/models/Container.py
@@ -191,6 +191,8 @@ class Container(db.Model): # type: ignore
       return True
     elif self.owner == user:
       return True
+    elif self.private == False:
+      return True
     else:
       return self.collection_ref.check_access(user)
   


### PR DESCRIPTION
It seems, the `private` attribute was somehow a dummy, I changed this to the following behaviour:

Now, private: yes means, it is my private thing
and private: no means, everybody with hinkskalle access can see it.